### PR TITLE
Remove Python 3.6 residues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 dist: xenial
 language: python
 python:
-  - 3.6
   - 3.7
   - 3.8
   - 3.9

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ Features
 
 Supported Python and Django versions:
 
-    - Python 3.6+
+    - Python 3.7+
     - `All supported versions of Django <https://www.djangoproject.com/download/#supported-versions>`_
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,15 +5,6 @@ envlist =
     pypy3-django2.2-es1.x,
     pypy3-django2.2-es2.x,
 
-    py36-django2.2-es1.x,
-    py36-django2.2-es2.x,
-    py36-django3.0-es1.x,
-    py36-django3.0-es2.x,
-    py36-django3.1-es1.x,
-    py36-django3.1-es2.x,
-    py36-django3.2-es1.x,
-    py36-django3.2-es2.x,
-
     py37-django2.2-es1.x,
     py37-django2.2-es2.x,
     py37-django3.0-es1.x,
@@ -83,7 +74,6 @@ deps =
 
 [testenv]
 basepython =
-    py36: python3.6
     py37: python3.7
     py38: python3.8
     py39: python3.9
@@ -119,74 +109,6 @@ setenv =
 deps =
     {[es2.x]deps}
     {[django2.2]deps}
-    {[base]deps}
-
-#
-# CPython3.6
-#
-
-[testenv:py36-django2.2-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
-    {[django2.2]deps}
-    {[base]deps}
-
-[testenv:py36-django2.2-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django2.2]deps}
-    {[base]deps}
-
-[testenv:py36-django3.0-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
-    {[django3.0]deps}
-    {[base]deps}
-
-[testenv:py36-django3.0-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django3.0]deps}
-    {[base]deps}
-
-[testenv:py36-django3.1-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
-    {[django3.1]deps}
-    {[base]deps}
-
-[testenv:py36-django3.1-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django3.1]deps}
-    {[base]deps}
-
-[testenv:py36-django3.2-es1.x]
-setenv =
-    {[es1.x]setenv}
-deps =
-    {[es1.x]deps}
-    {[django3.2]deps}
-    {[base]deps}
-
-[testenv:py36-django3.2-es2.x]
-setenv =
-    {[es2.x]setenv}
-deps =
-    {[es2.x]deps}
-    {[django3.2]deps}
     {[base]deps}
 
 #


### PR DESCRIPTION
`python_requires=">=3.7"` was added in #170