### PR TITLE
Drop Python 3.10

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   # renovate: datasource=python-version depName=python
-  PYTHON_VERSION: 3.10.20
+  PYTHON_VERSION: 3.11.15
   # renovate: datasource=pypi depName=uv
   UV_VERSION: 0.12.1
   # renovate: datasource=pypi depName=sphinx

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,6 @@ jobs:
         django-version:
           - "5.2.*"
         python-version:
-          - "3.10"
           - "3.11"
           - "3.12"
         elastic-version:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Fresh [documentation available](https://drf-haystack.readthedocs.io/en/latest/) 
 Supported versions
 ------------------
 
-- Python >=3.10, <3.13
+- Python >=3.11, <3.13
 - Django >=5.2,<5.3
 - Haystack >=2.8,<3.4
 - Django REST Framework >=3.12.0,<3.16

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Fresh [documentation available](https://drf-haystack.readthedocs.io/en/latest/) 
 Supported versions
 ------------------
 
-- Python >=3.10,<3.11
+- Python >=3.10, <3.13
 - Django >=5.2,<5.3
 - Haystack >=2.8,<3.4
 - Django REST Framework >=3.12.0,<3.16

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ Features
 
 Supported Python and Django versions:
 
-    - Python 3.10+
+    - Python >=3.10, <3.13
     - `All supported versions of Django <https://www.djangoproject.com/download/#supported-versions>`_
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ Features
 
 Supported Python and Django versions:
 
-    - Python >=3.10, <3.13
+    - Python >=3.11, <3.13
     - `All supported versions of Django <https://www.djangoproject.com/download/#supported-versions>`_
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     { name = "Rolf Håvard Blindheim", email = "rhblind@gmail.com" },
     { name = "Ülgen Sarıkavak", email = "foss@ulgenwanders.net" },
 ]
-requires-python = ">=3.10,<3.15"
+requires-python = ">=3.10,<3.13"
 classifiers = [
     # The package is being transferred between organizations and has no working tests / CI.
     # Use at your own risk.
@@ -24,8 +24,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP :: Indexing/Search",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     { name = "Rolf Håvard Blindheim", email = "rhblind@gmail.com" },
     { name = "Ülgen Sarıkavak", email = "foss@ulgenwanders.net" },
 ]
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.11,<3.13"
 classifiers = [
     # The package is being transferred between organizations and has no working tests / CI.
     # Use at your own risk.
@@ -21,7 +21,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Internet :: WWW/HTTP :: Indexing/Search",

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,6 @@
 line-length = 120
 
-target-version = "py310"
+target-version = "py311"
 
 [format]
 preview = true

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,7 +1,5 @@
 line-length = 120
 
-target-version = "py311"
-
 [format]
 preview = true
 

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,10 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Internet :: WWW/HTTP :: Indexing/Search",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    python_requires=">=3.10, <3.15",
+    python_requires=">=3.10, <3.13",
 )

--- a/setup.py
+++ b/setup.py
@@ -52,11 +52,10 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Topic :: Internet :: WWW/HTTP :: Indexing/Search",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    python_requires=">=3.10, <3.13",
+    python_requires=">=3.11, <3.13",
 )


### PR DESCRIPTION
It was about to EOL. Cleaning the matrix before adding new version supports.

https://endoflife.date/python