### PR TITLE
Add psuedo support for Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,23 +40,14 @@ jobs:
           - "3.14.*"
           - "3.15.*"
         exclude:
-          # DRF 3.12
+          # DRF 3.12 is just too old. Will be removed in https://github.com/ulgens/drf-haystack/pull/310
           - drf-version: "3.12.*"
-            python-version: "3.13"
-          - drf-version: "3.12.*"
-            python-version: "3.14"
 
-          # DRF 3.13
+          # DRF 3.13 is just too old. Will be removed in https://github.com/ulgens/drf-haystack/pull/310
           - drf-version: "3.13.*"
-            python-version: "3.13"
-          - drf-version: "3.13.*"
-            python-version: "3.14"
 
-          # DRF 3.14
+          # DRF 3.13 is just too old. Will be removed in https://github.com/ulgens/drf-haystack/pull/310
           - drf-version: "3.14.*"
-            python-version: "3.13"
-          - drf-version: "3.14.*"
-            python-version: "3.14"
 
           # DRF 3.15
           - drf-version: "3.15.*"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,8 @@ jobs:
         python-version:
           - "3.11"
           - "3.12"
+          - "3.13"
+          - "3.14"
         elastic-version:
           - "7.17.29"
         drf-version:
@@ -37,6 +39,30 @@ jobs:
           - "3.13.*"
           - "3.14.*"
           - "3.15.*"
+        exclude:
+          # DRF 3.12
+          - drf-version: "3.12.*"
+            python-version: "3.13"
+          - drf-version: "3.12.*"
+            python-version: "3.14"
+
+          # DRF 3.13
+          - drf-version: "3.13.*"
+            python-version: "3.13"
+          - drf-version: "3.13.*"
+            python-version: "3.14"
+
+          # DRF 3.14
+          - drf-version: "3.14.*"
+            python-version: "3.13"
+          - drf-version: "3.14.*"
+            python-version: "3.14"
+
+          # DRF 3.15
+          - drf-version: "3.15.*"
+            python-version: "3.13"
+          - drf-version: "3.15.*"
+            python-version: "3.14"
 
     env:
       UV_NO_DEV: 1

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Fresh [documentation available](https://drf-haystack.readthedocs.io/en/latest/) 
 Supported versions
 ------------------
 
-- Python >=3.11, <3.13
+- Python >=3.11, <3.15
 - Django >=5.2,<5.3
 - Haystack >=2.8,<3.4
 - Django REST Framework >=3.12.0,<3.16

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ Features
 
 Supported Python and Django versions:
 
-    - Python >=3.11, <3.13
+    - Python >=3.11, <3.15
     - `All supported versions of Django <https://www.djangoproject.com/download/#supported-versions>`_
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     { name = "Rolf Håvard Blindheim", email = "rhblind@gmail.com" },
     { name = "Ülgen Sarıkavak", email = "foss@ulgenwanders.net" },
 ]
-requires-python = ">=3.11,<3.13"
+requires-python = ">=3.11,<3.15"
 classifiers = [
     # The package is being transferred between organizations and has no working tests / CI.
     # Use at your own risk.
@@ -23,6 +23,8 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP :: Indexing/Search",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,10 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Internet :: WWW/HTTP :: Indexing/Search",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    python_requires=">=3.11, <3.13",
+    python_requires=">=3.11, <3.15",
 )


### PR DESCRIPTION
Currently we don't have any entries in test matrix, they will be added after DRF update: #310